### PR TITLE
feat(announcement): sync API & implement mobile-first attachment UI

### DIFF
--- a/src/entities/announcement/api.ts
+++ b/src/entities/announcement/api.ts
@@ -103,6 +103,7 @@ export const getAnnouncementById = cache(async function getAnnouncementById(
       date: item.createdDate,
 
       views: 0,
+      attachments: item.attachments || [],
     };
   } catch (error: any) {
     if (error.response?.status === 404) {

--- a/src/entities/announcement/model/types.ts
+++ b/src/entities/announcement/model/types.ts
@@ -47,6 +47,15 @@ export interface FetchAnnouncementsParams {
   toDate?: string;
 }
 
+export interface FileAttachment {
+  id: string;
+  fileName: string;
+  url: string;
+  size: number;
+  contentType: string;
+  type?: string;
+}
+
 export interface BackendAnnouncementDetail {
   id: string;
   title: string;
@@ -57,9 +66,9 @@ export interface BackendAnnouncementDetail {
   // createdByAvatar?: string;
   createdDate: string;
   modifiedDate: string | null;
-  // Backend hiện tại CHƯA TRẢ VỀ attachments.
+
   announcementTargetResponses: any[];
-  // attachments?: { id: string; name: string; url: string; type: string }[];
+  attachments: FileAttachment[];
 
   // views?: number;
 }
@@ -69,9 +78,10 @@ export interface AnnouncementDetail {
   title: string;
   content: string;
   category: string;
-  type: AnnouncementType; 
+  type: AnnouncementType;
   author: string;
-  avatarUrl?: string; 
+  avatarUrl?: string;
   date: string;
-  views: number; 
+  views: number;
+  attachments: FileAttachment[];
 }

--- a/src/entities/announcement/ui/attachment-item.tsx
+++ b/src/entities/announcement/ui/attachment-item.tsx
@@ -1,0 +1,48 @@
+import { FileAttachment } from "../model/types";
+import { FileIcon, ExternalLinkIcon } from "lucide-react";
+import Link from 'next/link';
+
+interface AttachmentItemProps {
+    attachment: FileAttachment;
+}
+
+export function AttachmentItem({ attachment }: AttachmentItemProps) {
+    return (
+        <Link
+            href={attachment.url}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="flex items-center p-3 mt-2 bg-white border border-gray-200 rounded-lg shadow-sm hover:bg-gray-50 active:scale-[0.98] transition-all duration-200 group min-h-[44px]"
+        >
+            {/* Icon Wrapper */}
+            <div className="flex-shrink-0 p-2 mr-3 bg-blue-50 rounded-lg group-hover:bg-blue-100 transition-colors">
+                <FileIcon className="w-5 h-5 text-blue-600" />
+            </div>
+
+            {/* Content */}
+            <div className="flex-1 min-w-0">
+                <p className="text-sm font-medium text-gray-900 truncate">
+                    {attachment.fileName}
+                </p>
+                <p className="text-xs text-gray-500 mt-0.5 flex items-center gap-2">
+                    {formatFileSize(attachment.size)}
+                    <span className="w-1 h-1 rounded-full bg-gray-300" />
+                    <span className="uppercase">{attachment.contentType.split('/').pop()}</span>
+                </p>
+            </div>
+
+            {/* Action Icon */}
+            <div className="flex-shrink-0 ml-3 text-gray-400 group-hover:text-blue-500">
+                <ExternalLinkIcon className="w-4 h-4" />
+            </div>
+        </Link>
+    );
+}
+
+function formatFileSize(bytes: number): string {
+    if (bytes === 0) return '0 B';
+    const k = 1024;
+    const sizes = ['B', 'KB', 'MB', 'GB', 'TB'];
+    const i = Math.floor(Math.log(bytes) / Math.log(k));
+    return parseFloat((bytes / Math.pow(k, i)).toFixed(1)) + ' ' + sizes[i];
+}


### PR DESCRIPTION
## Description

PR này cập nhật Client để tương thích với thay đổi API mới từ Backend, đồng thời implement giao diện hiển thị file đính kèm chuẩn Mobile First.

**Thay đổi chính:**
1.  **API Sync:** Loại bỏ tham số `classroomCode` trong `announcement.service.ts` (Backend tự handle).
2.  **Type Definition:** Cập nhật interface `FullAnnouncementResponse` để hứng trường `attachments` mới.
3.  **UI/UX:**
    - Thêm component hiển thị danh sách file đính kèm trong màn hình chi tiết.
    - **Mobile First:** Layout dạng list dọc, touch target > 44px dễ bấm trên điện thoại.
    - **Desktop:** Tự động chuyển sang Grid layout trên màn hình lớn.

## Related Issue(s)

- Depends on Backend PR #... (Điền link PR Backend vào đây)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- [x] **Responsive Test (Chrome DevTools):**
    - Kiểm tra hiển thị trên iPhone SE/Pixel 5: List file xếp dọc, không bị vỡ layout khi tên file dài.
    - Kiểm tra trên Desktop: List file xếp dạng Grid gọn gàng.
- [x] **Functional Test:**
    - Vào màn hình chi tiết thông báo -> Thấy danh sách file.
    - Click vào file -> Trigger download/mở tab mới thành công.

## Demo 

[Screencast from 2026-01-03 14-21-09.webm](https://github.com/user-attachments/assets/199def92-7d27-4653-9e5b-66d34d28f185)


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes